### PR TITLE
Make Docker Scout SARIF upload non-fatal

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -89,9 +89,16 @@ jobs:
       # Docker Scout's sarif-file output was only ever archived as a downloadable artifact --
       # findings never reached the Security tab, so nobody would see a new CVE without manually
       # opening a workflow run and downloading the file. This surfaces them like hadolint.yml
-      # already does for its own SARIF output.
+      # already does for its own SARIF output. continue-on-error: true because Scout's SARIF for
+      # this image has genuinely tripped GitHub's own per-result related-locations cap before
+      # ("rejecting SARIF, as there are more related locations per result than allowed
+      # (2427 > 1000)", confirmed live) -- a single widespread base-image CVE can legitimately
+      # list more affected paths than that. The scan (and its artifact upload above) already ran
+      # regardless; this step is a best-effort mirror to the Security tab, not something that
+      # should fail the build when GitHub's own ingestion limit is hit.
       - name: Upload Docker Scout results to the Security tab
         uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: true
         with:
           sarif_file: sarif.output.json
           category: docker-scout

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -50,8 +50,13 @@ jobs:
     # Docker Scout's sarif-file output was only ever archived as a downloadable artifact --
     # findings never reached the Security tab, so a new CVE surfacing on this workflow's 5-day
     # schedule would go unnoticed without manually opening a run and downloading the file.
+    # continue-on-error: true -- confirmed live that Scout's SARIF for this image can trip
+    # GitHub's own per-result related-locations cap ("rejecting SARIF, as there are more related
+    # locations per result than allowed (2427 > 1000)"); the scan and artifact upload above still
+    # ran regardless, this is just a best-effort mirror to the Security tab.
     - name: Upload Docker Scout results to the Security tab
       uses: github/codeql-action/upload-sarif@v3
+      continue-on-error: true
       with:
         sarif_file: sarif.output.json
         category: docker-scout-scheduled


### PR DESCRIPTION
## Summary
A real build just failed: *"Code Scanning could not process the submitted SARIF file: rejecting SARIF, as there are more related locations per result than allowed (2427 > 1000)"*. The Docker build/push and the Scout scan itself both succeeded -- only the new `upload-sarif` step I'd just added failed, and it's not a fluke: a single widespread base-image CVE can legitimately list more affected paths than GitHub's own per-result cap, so this would recur on every run.

Added `continue-on-error: true` to both `docker-image.yml`'s and `scan.yml`'s `upload-sarif` steps. The scan and its artifact upload (the original, working behavior) are unaffected; the Security-tab mirror is now best-effort instead of build-blocking. Caveat worth knowing: when the cap trips, the whole SARIF upload is rejected (not just the oversized result), so that day's findings won't show in the Security tab -- the full report is still available via the existing artifact download regardless.

## Test plan
- [ ] Merge, manually dispatch `docker-image.yml`, confirm the whole job (including the SARIF step) completes without failing the build this time